### PR TITLE
24 hour format support

### DIFF
--- a/app/src/main/java/com/flux/data/database/FluxDatabase.kt
+++ b/app/src/main/java/com/flux/data/database/FluxDatabase.kt
@@ -27,7 +27,7 @@ import com.flux.data.model.WorkspaceModel
 
 @Database(
     entities = [EventModel::class, LabelModel::class, EventInstanceModel::class, SettingsModel::class, NotesModel::class, HabitModel::class, HabitInstanceModel::class, WorkspaceModel::class, TodoModel::class, JournalModel::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(Converter::class)

--- a/app/src/main/java/com/flux/data/database/Migrations.kt
+++ b/app/src/main/java/com/flux/data/database/Migrations.kt
@@ -1,0 +1,14 @@
+package com.flux.data.database
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE SettingsModel ADD COLUMN is24HourFormat INTEGER NOT NULL DEFAULT 0")
+    }
+}
+
+val ALL_MIGRATIONS = arrayOf(
+    MIGRATION_1_2
+)

--- a/app/src/main/java/com/flux/data/model/SettingsModel.kt
+++ b/app/src/main/java/com/flux/data/model/SettingsModel.kt
@@ -17,5 +17,6 @@ data class SettingsModel(
     val dynamicTheme: Boolean = false,
     val amoledTheme: Boolean = false,
     val isScreenProtection: Boolean = false,
-    val workspaceGridColumns: Int = 1
+    val workspaceGridColumns: Int = 1,
+    val is24HourFormat: Boolean = false
 )

--- a/app/src/main/java/com/flux/di/DataModule.kt
+++ b/app/src/main/java/com/flux/di/DataModule.kt
@@ -12,6 +12,7 @@ import com.flux.data.dao.NotesDao
 import com.flux.data.dao.SettingsDao
 import com.flux.data.dao.TodoDao
 import com.flux.data.dao.WorkspaceDao
+import com.flux.data.database.ALL_MIGRATIONS
 import com.flux.data.database.FluxDatabase
 import dagger.Module
 import dagger.Provides
@@ -32,7 +33,7 @@ object DataModule {
         app,
         FluxDatabase::class.java,
         "FluxDatabase"
-    ).build()
+    ).addMigrations(*ALL_MIGRATIONS).build()
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/flux/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/flux/navigation/NavRoutes.kt
@@ -107,6 +107,7 @@ val HabitScreens =
                 states.habitState.allHabits.find { it.habitId == habitId }
                     ?: HabitModel(workspaceId = workspaceId),
                 states.habitState.allInstances.filter { it.habitId == habitId },
+                states.settings,
                 viewModel.habitViewModel::onEvent
             )
         }
@@ -172,6 +173,7 @@ val EventScreens =
                     ?: EventModel(workspaceId = workspaceId),
                 states.eventState.allEventInstances.find { it.eventId == eventId && it.instanceDate == LocalDate.now() }
                     ?: EventInstanceModel(eventId = eventId, instanceDate = LocalDate.now()),
+                states.settings,
                 viewModels.eventViewModel::onEvent
             )
         }

--- a/app/src/main/java/com/flux/ui/components/BottomSheets.kt
+++ b/app/src/main/java/com/flux/ui/components/BottomSheets.kt
@@ -183,7 +183,7 @@ fun HabitBottomSheet(
                     )
 
                     Text(
-                        text = newHabitTime.toFormattedTime(),
+                        text = newHabitTime.toFormattedTime(settings.data.is24HourFormat),
                         style = MaterialTheme.typography.titleLarge
                     )
                 }

--- a/app/src/main/java/com/flux/ui/components/BottomSheets.kt
+++ b/app/src/main/java/com/flux/ui/components/BottomSheets.kt
@@ -66,6 +66,7 @@ import com.flux.data.model.WorkspaceModel
 import com.flux.other.icons
 import com.flux.other.workspaceIconList
 import com.flux.ui.screens.events.toFormattedTime
+import com.flux.ui.state.Settings
 import java.util.Calendar
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -75,6 +76,7 @@ fun HabitBottomSheet(
     habit: HabitModel? = null,
     isVisible: Boolean,
     sheetState: SheetState,
+    settings: Settings,
     onConfirm: (HabitModel, Long) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
@@ -234,6 +236,7 @@ fun HabitBottomSheet(
             if (timePickerDialog) {
                 TimePicker(
                     initialTime = newHabitTime,
+                    is24Hour = settings.data.is24HourFormat,
                     onConfirm = {
                         val habitCalendar = Calendar.getInstance().apply {
                             timeInMillis = newHabitTime

--- a/app/src/main/java/com/flux/ui/components/Dialog.kt
+++ b/app/src/main/java/com/flux/ui/components/Dialog.kt
@@ -322,8 +322,9 @@ fun convertMillisToDate(millis: Long): String {
     return formatter.format(Date(millis))
 }
 
-fun convertMillisToTime(millis: Long): String {
-    val formatter = SimpleDateFormat("hh:mm a", Locale.getDefault())
+fun convertMillisToTime(millis: Long, is24Hour: Boolean = false): String {
+    val pattern = if (is24Hour) "HH:mm" else "hh:mm a"
+    val formatter = SimpleDateFormat(pattern, Locale.getDefault())
     return formatter.format(Date(millis))
 }
 
@@ -331,6 +332,7 @@ fun convertMillisToTime(millis: Long): String {
 @Composable
 fun TimePicker(
     initialTime: Long,
+    is24Hour: Boolean = false,
     onConfirm: (TimePickerState) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -339,7 +341,7 @@ fun TimePicker(
     val timePickerState = rememberTimePickerState(
         initialHour = currentTime.get(Calendar.HOUR_OF_DAY),
         initialMinute = currentTime.get(Calendar.MINUTE),
-        is24Hour = false,
+        is24Hour = is24Hour,
     )
 
     var showDial by remember { mutableStateOf(true) }

--- a/app/src/main/java/com/flux/ui/components/Dialog.kt
+++ b/app/src/main/java/com/flux/ui/components/Dialog.kt
@@ -323,7 +323,7 @@ fun convertMillisToDate(millis: Long): String {
 }
 
 fun convertMillisToTime(millis: Long, is24Hour: Boolean = false): String {
-    val pattern = if (is24Hour) "HH:mm" else "hh:mm a"
+    val pattern = if (is24Hour) "HH'h'mm" else "hh:mm a"
     val formatter = SimpleDateFormat(pattern, Locale.getDefault())
     return formatter.format(Date(millis))
 }

--- a/app/src/main/java/com/flux/ui/components/HabitComponents.kt
+++ b/app/src/main/java/com/flux/ui/components/HabitComponents.kt
@@ -61,6 +61,7 @@ import com.flux.ui.events.HabitEvents
 import com.flux.ui.screens.events.IconRadioButton
 import com.flux.ui.screens.events.toFormattedDate
 import com.flux.ui.screens.events.toFormattedTime
+import com.flux.ui.state.Settings
 import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
@@ -144,6 +145,7 @@ fun HabitPreviewCard(
     radius: Int,
     habit: HabitModel,
     instances: List<HabitInstanceModel>,
+    settings: Settings,
     onToggleDone: (LocalDate) -> Unit,
     onAnalyticsClicked: () -> Unit
 ) {
@@ -192,7 +194,7 @@ fun HabitPreviewCard(
                                     overflow = TextOverflow.Ellipsis
                                 )
                                 Text(
-                                    habit.startDateTime.toFormattedTime(),
+                                    habit.startDateTime.toFormattedTime(settings.data.is24HourFormat),
                                     style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.ExtraLight),
                                     modifier = Modifier.alpha(0.9f)
                                 )

--- a/app/src/main/java/com/flux/ui/screens/calendar/Calendar.kt
+++ b/app/src/main/java/com/flux/ui/screens/calendar/Calendar.kt
@@ -97,6 +97,7 @@ fun LazyListScope.calenderItems(
                     timeline = task.startDateTime,
                     description = task.description,
                     repeat = task.repetition,
+                    settings = settings,
                     onChangeStatus = { onTaskEvents(TaskEvents.ToggleStatus(it)) },
                     onClick = {
                         navController.navigate(
@@ -122,6 +123,7 @@ fun LazyListScope.calenderItems(
                     timeline = task.startDateTime,
                     description = task.description,
                     repeat = task.repetition,
+                    settings = settings,
                     onChangeStatus = { onTaskEvents(TaskEvents.ToggleStatus(it)) },
                     onClick = {
                         navController.navigate(

--- a/app/src/main/java/com/flux/ui/screens/events/EventDetails.kt
+++ b/app/src/main/java/com/flux/ui/screens/events/EventDetails.kt
@@ -301,7 +301,7 @@ fun EventDetails(
                     )
                     if (!checked) {
                         Text(
-                            convertMillisToTime(selectedDateTime),
+                            convertMillisToTime(selectedDateTime, settings.data.is24HourFormat),
                             modifier = Modifier
                                 .clickable { showTimePicker = true }
                                 .padding(4.dp)

--- a/app/src/main/java/com/flux/ui/screens/events/EventDetails.kt
+++ b/app/src/main/java/com/flux/ui/screens/events/EventDetails.kt
@@ -65,6 +65,7 @@ import com.flux.ui.components.TimePicker
 import com.flux.ui.components.convertMillisToDate
 import com.flux.ui.components.convertMillisToTime
 import com.flux.ui.events.TaskEvents
+import com.flux.ui.state.Settings
 import com.flux.ui.theme.completed
 import com.flux.ui.theme.pending
 import java.util.Calendar
@@ -75,6 +76,7 @@ fun EventDetails(
     navController: NavController,
     event: EventModel,
     eventInstance: EventInstanceModel,
+    settings: Settings,
     onTaskEvents: (TaskEvents) -> Unit
 ) {
     val context = LocalContext.current
@@ -122,6 +124,7 @@ fun EventDetails(
     if (showTimePicker) {
         TimePicker(
             initialTime = selectedDateTime,
+            is24Hour = settings.data.is24HourFormat,
             onConfirm = {
                 val calendar = Calendar.getInstance().apply {
                     timeInMillis = selectedDateTime

--- a/app/src/main/java/com/flux/ui/screens/habits/HabitDetails.kt
+++ b/app/src/main/java/com/flux/ui/screens/habits/HabitDetails.kt
@@ -27,6 +27,7 @@ import com.flux.ui.components.HabitStreakCard
 import com.flux.ui.components.MonthlyHabitAnalyticsCard
 import com.flux.ui.components.calculateStreaks
 import com.flux.ui.events.HabitEvents
+import com.flux.ui.state.Settings
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -37,6 +38,7 @@ fun HabitDetails(
     workspaceId: Long,
     habit: HabitModel,
     habitInstances: List<HabitInstanceModel>,
+    settings: Settings,
     onHabitEvents: (HabitEvents) -> Unit
 ) {
     var showHabitDialog by remember { mutableStateOf(false) }
@@ -85,6 +87,7 @@ fun HabitDetails(
         habit = habit,
         isVisible = showHabitDialog,
         sheetState = sheetState,
+        settings = settings,
         onDismissRequest = {
             scope.launch { sheetState.hide() }.invokeOnCompletion { showHabitDialog = false }
         },

--- a/app/src/main/java/com/flux/ui/screens/habits/Habits.kt
+++ b/app/src/main/java/com/flux/ui/screens/habits/Habits.kt
@@ -14,6 +14,7 @@ import com.flux.navigation.NavRoutes
 import com.flux.ui.components.EmptyHabits
 import com.flux.ui.components.HabitPreviewCard
 import com.flux.ui.events.HabitEvents
+import com.flux.ui.state.Settings
 
 fun LazyListScope.habitsHomeItems(
     navController: NavController,
@@ -22,6 +23,7 @@ fun LazyListScope.habitsHomeItems(
     workspaceId: Long,
     allHabits: List<HabitModel>,
     allInstances: List<HabitInstanceModel>,
+    settings: Settings,
     onHabitEvents: (HabitEvents) -> Unit
 ) {
     when {
@@ -34,6 +36,7 @@ fun LazyListScope.habitsHomeItems(
                     radius = radius,
                     habit = habit,
                     instances = habitInstances,
+                    settings = settings,
                     onToggleDone = { date ->
                         val existing = habitInstances.find { it.instanceDate == date }
                         if (existing != null) {

--- a/app/src/main/java/com/flux/ui/screens/settings/Customize.kt
+++ b/app/src/main/java/com/flux/ui/screens/settings/Customize.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Colorize
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
@@ -307,8 +308,7 @@ fun Customize(
                     description = stringResource(R.string.Monthly_View_Desc),
                     icon = Icons.Rounded.GridOn,
                     radius = shapeManager(
-                        radius = settings.data.cornerRadius,
-                        isLast = true
+                        radius = settings.data.cornerRadius
                     ),
                     variable = settings.data.isCalendarMonthlyView,
                     actionType = ActionType.SWITCH,
@@ -321,6 +321,29 @@ fun Customize(
                             )
                         )
                     },
+                )
+            }
+
+            item {
+                SettingOption(
+                    title = stringResource(R.string.Hour_Format_24),
+                    description = stringResource(R.string.Hour_Format_24_Desc),
+                    icon = Icons.Filled.AccessTime,
+                    radius = shapeManager(
+                        radius = settings.data.cornerRadius,
+                        isLast = true
+                    ),
+                    actionType = ActionType.SWITCH,
+                    variable = settings.data.is24HourFormat,
+                    switchEnabled = {
+                        onSettingsEvents(
+                            SettingEvents.UpdateSettings(
+                                settings.data.copy(
+                                    is24HourFormat = it
+                                )
+                            )
+                        )
+                    }
                 )
             }
 

--- a/app/src/main/java/com/flux/ui/screens/workspaces/WorkspaceDetails.kt
+++ b/app/src/main/java/com/flux/ui/screens/workspaces/WorkspaceDetails.kt
@@ -303,6 +303,7 @@ fun WorkspaceDetails(
                     workspace.workspaceId,
                     allHabits,
                     allHabitInstances,
+                    settings,
                     onHabitEvents
                 )
             }
@@ -365,6 +366,7 @@ fun WorkspaceDetails(
                     isAllEventsLoading,
                     allEvents,
                     allEventInstances,
+                    settings,
                     workspaceId,
                     onTaskEvents
                 )

--- a/app/src/main/java/com/flux/ui/screens/workspaces/WorkspaceDetails.kt
+++ b/app/src/main/java/com/flux/ui/screens/workspaces/WorkspaceDetails.kt
@@ -439,6 +439,7 @@ fun WorkspaceDetails(
     HabitBottomSheet(
         isVisible = showHabitDialog,
         sheetState = sheetState,
+        settings = settings,
         onDismissRequest = {
             scope.launch { sheetState.hide() }.invokeOnCompletion { showHabitDialog = false }
         },

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -159,6 +159,8 @@
     <string name="enterPasskey">Entrer le code secret</string>
     <string name="Amount">Montant</string>
     <string name="Today">Aujourd\'hui</string>
+    <string name="at">à</string>
+    <string name="on">le</string>
 
     <!-- Calender -->
     <string name="Calender">Calendrier</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -56,6 +56,8 @@
     <string name="Developer_Name">Ronit Chinda</string>
     <string name="Source_Code">Code Source</string>
     <string name="Github_Repository">Dépôt Github</string>
+    <string name="Hour_Format_24">Format 24 heures</string>
+    <string name="Hour_Format_24_Desc">Utiliser le format d\'heure 24 heures</string>
 
     <!-- Common -->
     <string name="Pin">Épingler</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,8 @@
     <string name="enterPasskey">Enter Passkey</string>
     <string name="Amount">Amount</string>
     <string name="Today">Today</string>
+    <string name="at">at</string>
+    <string name="on">on</string>
 
     <!-- Calendar -->
     <string name="Calendar">Calendar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,8 @@
     <string name="Developer_Name">Ronit Chinda</string>
     <string name="Source_Code">Source Code</string>
     <string name="Github_Repository">Github Repository</string>
+    <string name="Hour_Format_24">24-Hour Format</string>
+    <string name="Hour_Format_24_Desc">Use 24-hour time format</string>
 
     <!-- Common -->
     <string name="Pin">Pin</string>


### PR DESCRIPTION
24 hour format is now available in settings under 'Shape - View' (not sure if this is the best place), it changes the is24HourFormat parameter.

- Created a Migration file for all the migrations in the db and changed the version to 2.
- Modified the different helping function to use is24HourFormat so I needed to modify a lot of file to pass the settings.
- Added two string resource: 'at' and 'on' for translating in other language.
- getDayOfMonthSuffix now support others language for the prefix.

Also I fucked up with the different commit and somehow included whole file:
- Calendar and WorkspaceDetails where I just changed the functions to pass settings.
- EventHome where I improved and changed the different helping functions for time related things.

I'm sorry but I wasn't able to figure out how to resolve the different commit to have the proper change, I'm still learning to use git and github so please ignore my mistake...